### PR TITLE
Feature/check remote addr

### DIFF
--- a/class/Session.php
+++ b/class/Session.php
@@ -48,6 +48,9 @@ class Ethna_Session
         'suffix'            => 'SESSID',
     );
 
+    /** @protected    bool  IPアドレスの範囲チェックをするかどうか */
+    protected $validateRemoteAddr = false;
+
     /**#@-*/
 
     /**
@@ -138,6 +141,11 @@ class Ethna_Session
                 setcookie($this->session_name, "", 0, "/");
             }
             return false;
+        }
+
+        //do IP check or not
+        if (!$this->validateRemoteAddr) {
+            return true;
         }
 
         // check remote address


### PR DESCRIPTION
携帯サイトを作る場合は、validateRemoteAddrを無効にする必要があります。

validateRemoteAddrを丸ごとオーバーライドする方法がよく紹介されています。

on/off切替えをもう少し簡単にできるとよいのではないでしょうか。

セキュリティとの兼ね合いはありますが、携帯サイトのことを考えるとデフォルト無効の方が親切だと思います。

参考：http://dqn.sakusakutto.jp/2011/10/ethna_validateremoteaddr.html
