### PR TITLE
Feature/bugfix require smarty

### DIFF
--- a/class/Renderer.php
+++ b/class/Renderer.php
@@ -327,7 +327,7 @@ class Ethna_Renderer
                 require_once $engine_path;
             }
             else {
-                trigger_error("template engine is not available: path=" . $engine_path, E_USER_ERROR);
+                throw new Exception("template engine is not available: path=" . $engine_path);
             }
         }
     }


### PR DESCRIPTION
Smartyがインストールされてない状態でethna_run_test.php を実行すると、
test_redirect_500の途中でテストが終了してしまいます。

https://gist.github.com/1278681/36c6f8a1fb4177d1008cfa148ab2789ceb93b279

エラーが出ないので、異常終了したことに気づかないです。
具体的には、
function runMain内の@演算子のために、Renderer.phpが発するエラーが抑制されてしまい、「"Smarty"へのパスが通ってないのが原因」ということに気づきくくなっています。

@$c->trigger($action_name, "");  // suppress header related error.

例外を吐くことで、テスト実行者は異常に気づけると思います。
ご検討よろしくお願いします。
