### PR TITLE
Feature/bugfix  get memcache info

### DIFF
--- a/class/Plugin/Cachemanager/Memcache.php
+++ b/class/Plugin/Cachemanager/Memcache.php
@@ -114,7 +114,9 @@ class Ethna_Plugin_Cachemanager_Memcache extends Ethna_Plugin_Cachemanager
         // namespace/cache_keyで接続先を決定
         $n = count($memcache_info[$namespace]);
 
-        $index = $cache_key % $n;
+        $crc32_key = crc32($cache_key);
+        $index = abs($crc32_key) % $n;
+
         return array(
             isset($memcache_info[$namespace][$index]['host']) ?
                 $memcache_info[$namespace][$index]['host'] :


### PR DESCRIPTION
もともと
 $index = $cache_key % $n;
となってました。

これでは$indexが常にゼロになってしまい、memcacheサーバを複数たてても、常に１つのサーバにアクセスしてしまいます。(分散されない)

本来は下記のような剰余による分散を意図していたのではないかと思われます。
http://gihyo.jp/dev/feature/01/memcached/0004?page=2

分散アルゴリズムもいろいろありますが、まずは分散することが大事かと思いました。
