### PR TITLE
Feature/bugfix memcache delete

### DIFF
--- a/class/Plugin/Cachemanager/Memcache.php
+++ b/class/Plugin/Cachemanager/Memcache.php
@@ -263,7 +263,7 @@ class Ethna_Plugin_Cachemanager_Memcache extends Ethna_Plugin_Cachemanager
             return Ethna::raiseError('invalid cache key (too long?)', E_CACHE_NO_VALUE);
         }
 
-        $this->memcache->delete($cache_key, -1);
+        $this->memcache->delete($cache_key);
     }
 
     /**


### PR DESCRIPTION
バグ修正です。

http://jp.php.net/manual/ja/memcache.delete.php

delete()の第二引数は「使ってはいけません」となっています。
実際、削除がうまくいかなかったことがありました。
