### PR TITLE
Feature/action error add object log info

### DIFF
--- a/class/ActionError.php
+++ b/class/ActionError.php
@@ -81,7 +81,7 @@ class Ethna_ActionError
         // ログ出力(補足)
         $af = $this->_getActionForm();
         $logger = $this->_getLogger();
-        $logger->log(LOG_NOTICE, '{form} -> [%s]', $this->action_form->getName($name));
+        $logger->log(LOG_INFO, '{form} -> [%s]', $this->action_form->getName($name));
     }
 
     /**


### PR DESCRIPTION
提案です。

前から気になっていたのですが、validateで発生するエラーは、アプリケーションとして正常な動作だと思うので、LOG_INFOの方がよいのではないでしょうか。

「開発環境でのNoticeは全部つぶす」というルールで運用している場合、ここがLOG_INFOになってる方がありがたいです。

現状ではMy_ActionErrorなどでオーバーライドするしかないのですが、 _getActionForm, _getLoggerがprivateなのでオーバーライドが広範囲になってしまいます。
