### PR TITLE
Feature/bugfix

### DIFF
--- a/class/DB/ADOdb.php
+++ b/class/DB/ADOdb.php
@@ -87,7 +87,11 @@ class Ethna_DB_ADOdb extends Ethna_DB
             $this->db->SetFetchMode(ADODB_FETCH_ASSOC);
             return true;
         } else {
-            return false;
+            $error = Ethna::raiseError('DB Connection Error: %s',
+                E_DB_CONNECT,
+                $this->dsn);
+            $this->db = null;
+            return $error;
         }
     }
     //}}}


### PR DESCRIPTION
Ethna_DB_ADOdb::connectはboolを返すようになっていますが、Ethna_Backend::getDBではEthna::isErrorで接続成否をチェックしています。
そのため、ADOdbを使用するとDB接続が失敗してもDBオブジェクトの生成は成功したことになってしまいます。
