### PR TITLE
テーブル名に SQL の予約語を使うと特定の条件下でエラーするのを修正

### DIFF
--- a/class/DB/PEAR.php
+++ b/class/DB/PEAR.php
@@ -220,7 +220,7 @@ class Ethna_DB_PEAR extends Ethna_DB
      */
     public function getMetaData($table)
     {
-        $def = $this->db->tableInfo($table);
+        $def = $this->db->tableInfo($this->db->quoteIdentifier($table));
         if (is_array($def) === false) {
             return $def;
         }


### PR DESCRIPTION
テーブル名に SQL の予約語を使った際 `Ethna_AppObject` の `$prop_def` を省略した場合に実行される `Ethna_DB_PEAR#getMetaData()` が、テーブル名をエスケープしないため、クエリが構文エラーとなり、`$prop_def` の構築に失敗し、以降のクエリが正常に発行されなくなります。
- テーブル名を `release` とした場合 logger から出力されるエラー。

```
2010/03/09 16:46:17 Appid(DEBUG): SELECT COUNT(DISTINCT `release`.``) AS `id_count` FROM `release`
2010/03/09 16:46:17 Appid(ERR): Query Error SQL[SELECT COUNT(DISTINCT `release`.``) AS `id_count` FROM `release` ] CODE[1054] MESSAGE[SELECT COUNT(DISTINCT `release`.``) AS `id_count` FROM `release`  [nativecode=1054 ** Unknown column 'release.' in 'field list']] [ERROR CODE(4)]
```
- 生成されるクエリ (`release` は予約語のため構文エラー)

``` sql
SELECT * FROM release LIMIT 0
```

テーブル名に予約語を使った場合でも正しくクエリが生成されるよう、テーブル名をエスケープするようにしました。
- このパッチを適用した場合に生成されるクエリ (テーブル名がエスケープされるのでエラーしない)

``` sql
SELECT * FROM `release` LIMIT 0
```

# 本質的にこのようなテーブル設計は避けるべきですが、やれる対応はやっておくという方針で...
