### PR TITLE
Ethna_DB::connectの実装・仕様・コメントの統一

### DIFF
--- a/class/DB.php
+++ b/class/DB.php
@@ -55,7 +55,7 @@ class Ethna_DB
      *  DBに接続する
      *
      *  @access public
-     *  @return mixed   0:正常終了 Ethna_Error:エラー
+     *  @return mixed   0:成功 Ethna_Error:エラー
      */
     public function connect()
     {

--- a/class/DB/ADOdb.php
+++ b/class/DB/ADOdb.php
@@ -69,7 +69,7 @@ class Ethna_DB_ADOdb extends Ethna_DB
      *  DBに接続する
      *
      *  @access public
-     *  @return bool   true:成功 false:失敗
+     *  @return mixed   0:成功 Ethna_Error:エラー
      */
     public function connect()
     {
@@ -85,7 +85,7 @@ class Ethna_DB_ADOdb extends Ethna_DB
 
         if ( $this->db ) {
             $this->db->SetFetchMode(ADODB_FETCH_ASSOC);
-            return true;
+            return 0;
         } else {
             $error = Ethna::raiseError('DB Connection Error: %s',
                 E_DB_CONNECT,

--- a/class/DB/PEAR.php
+++ b/class/DB/PEAR.php
@@ -85,7 +85,7 @@ class Ethna_DB_PEAR extends Ethna_DB
      *  DBに接続する
      *
      *  @access public
-     *  @return mixed   0:正常終了 Ethna_Error:エラー
+     *  @return mixed   0:成功 Ethna_Error:エラー
      */
     public function connect()
     {


### PR DESCRIPTION
■実装、仕様、コメント、すべて統一しました。

成功：0
失敗：Ethna_Error

■日本語を変えました。

「正常終了」だと違和感があるので「成功」に変えました。
