### PR TITLE
Feature/fixurlhandler

### DIFF
--- a/class/Plugin/Smarty/function.url.php
+++ b/class/Plugin/Smarty/function.url.php
@@ -21,7 +21,7 @@ function smarty_function_url($params, &$smarty)
     $url_handler = $c->getUrlHandler();
     list($path, $path_key) = $url_handler->actionToRequest($action, $query);
 
-    if ($path != "") {
+    if (!is_null($path)) {
         if (is_array($path_key)) {
             foreach ($path_key as $key) {
                 unset($query[$key]);

--- a/class/UrlHandler.php
+++ b/class/UrlHandler.php
@@ -96,7 +96,7 @@ class Ethna_UrlHandler
             return null;
         }
         list($path, $path_key) = $this->$method($action, $param);
-        if ($path == "") {
+        if (is_null($path)) {
             return null;
         }
 

--- a/test/Plugin/Smarty/Plugin_Smarty_function_url_Test.php
+++ b/test/Plugin/Smarty/Plugin_Smarty_function_url_Test.php
@@ -41,6 +41,13 @@ class Ethna_Plugin_Smarty_function_url_Test extends Ethna_UnitTestBase
                 'path_ext'      => false,
             ),
         ),
+        'emptypath' => array(
+            'test_empty_path' => array(
+                'path'          => '',
+                'path_regexp'   => false,
+                'path_ext'      => false,
+            ),
+        ),
     );
     // }}}
 
@@ -122,6 +129,23 @@ class Ethna_Plugin_Smarty_function_url_Test extends Ethna_UnitTestBase
         $this->assertEqual($expected, $actual);
     }
     // }}}
+
+    // {{{ test_smarty_function_url_emptypath
+    function test_smarty_function_url_emptypath()
+    {
+        $params = array('action' => 'test_empty_path',
+                        'anchor' => '',
+                        'scheme' => '',
+                        'param1' => 'hoge',
+                        'param2' => 'huga',
+                  );
+        $dummy_smarty = null;
+        $expected = "?param1=hoge&param2=huga";
+
+        $actual = smarty_function_url($params, $dummy_smarty);
+        $this->assertEqual($expected, $actual);
+    }
+    // }}}
 }
 // }}}
 
@@ -154,6 +178,11 @@ class Ethna_Plugin_Smarty_function_url_Test_UrlHandler
     function _getPath_Entrypoint($action, $params)
     {
         return array('/entrypoint', array());
+    }
+
+    function _getPath_Emptypath($action, $params)
+    {
+        return array('', array());
     }
 
     public function setActionMap($am)

--- a/test/UrlHandler_Test.php
+++ b/test/UrlHandler_Test.php
@@ -26,6 +26,13 @@ class Ethna_UrlHandler_Test extends Ethna_UnitTestBase
                 'path_ext'      => false,
             ),
         ),
+        'emptypath' => array(
+            'test_empty_path' => array(
+                'path'          => '',
+                'path_regexp'   => false,
+                'path_ext'      => false,
+            ),
+        ),
     );
     // }}}
 
@@ -309,6 +316,26 @@ class Ethna_UrlHandler_Test extends Ethna_UnitTestBase
         $this->assertEqual($path_key, array('param1', 'param2'));
     }
     // }}}
+
+    // {{{ test_actionToRequest_emptypath
+    function test_actionToRequest_emptypath()
+    {
+        $action = 'test_empty_path';
+        $param = array(
+            'hoge' => 'fuga',
+        );
+
+        $this->url_handler->setActionMap($this->_simple_map);
+        $ret = $this->url_handler->actionToRequest($action, $param);
+        $this->assertFalse(is_null($ret));
+        list($path, $path_key) = $ret;
+
+        // action "test_empty_path" に対応するのは "emptypath" の ""
+        $this->assertEqual($path, '');
+        $this->assertTrue($path_key == array());
+    }
+    // }}}
+
 }
 
 class Ethna_UrlHandler_TestClass extends Ethna_UrlHandler
@@ -316,6 +343,11 @@ class Ethna_UrlHandler_TestClass extends Ethna_UrlHandler
     function _getPath_Entrypoint($action, $params)
     {
         return array('/entrypoint', array());
+    }
+
+    function _getPath_Emptypath($action, $params)
+    {
+        return array('', array());
     }
 
     function _normalizerequest_Test($http_vars)


### PR DESCRIPTION
UrlHandler::actionToRequest() で空文字列の path を生成すると、
default のクエリ形式 (?action_foo=true) にされてしまいます。
null のみを default fallback 扱いとして、空 path を許容するようにしました。

smarty_function_url() のテストも追加しました。

mod_rewrite の使用や、別実装の UrlHandler を使う場合に自由度が増します。
