### PR TITLE
Feature/protected  get action name

### DIFF
--- a/class/Controller.php
+++ b/class/Controller.php
@@ -1216,11 +1216,11 @@ class Ethna_Controller
     /**
      *  実行するアクション名を返す
      *
-     *  @access private
+     *  @access protected
      *  @param  mixed   $default_action_name    指定のアクション名
      *  @return string  実行するアクション名
      */
-    private function _getActionName($default_action_name, $fallback_action_name)
+    protected function _getActionName($default_action_name, $fallback_action_name)
     {
         // フォームから要求されたアクション名を取得する
         $form_action_name = $this->_getActionName_Form();


### PR DESCRIPTION
_trigger_WWWをアプリ側のコントローラーで継承することがよくあるのですが、_getActionNameがprivateだと呼び出せなくて不便です。
_getAction, _ethnaManagerEnabledCheckなどはprotectedなので、 _getActionNameもprotectedで問題ないかと思われます。

よろしくお願いします。
