### PR TITLE
fix bug ( do not convert null to zero-lenght string '' )

### DIFF
--- a/class/ActionForm.php
+++ b/class/ActionForm.php
@@ -579,6 +579,8 @@ class Ethna_ActionForm
             if (is_array($vars[$name])) {
                 $retval[$name] = array();
                 $this->_getArray($vars[$name], $retval[$name], $escape);
+            } else if (is_null($vars[$name])) {
+                $retval[$name] = null;
             } else {
                 $retval[$name] = $escape
                     ? htmlspecialchars($vars[$name], ENT_QUOTES) : $vars[$name];


### PR DESCRIPTION
$this->af->getArray()のバグと思われます。

例えばフォーム値未入力の場合、

``` php
$this->af->get('hoge');  //  => null
$form_vars = $this->af->getArray();
$form_vars['hoge'];    // => ''
```

となってしまい、nullが空文字に変換されてしまいます。
これはユーザが期待する挙動と異なるので、nullはnullのままの方がよいかと思います。
