### PR TITLE
エラーハンドラの設定前に Logger を生成する

### DIFF
--- a/class/Controller.php
+++ b/class/Controller.php
@@ -215,6 +215,9 @@ class Ethna_Controller
         $class_factory = $this->class['class'];
         $this->class_factory = new $class_factory($this, $this->class);
 
+        // ログ管理オブジェクトの用意
+        $this->logger = $this->getLogger();
+
         // エラーハンドラの設定
         Ethna::setErrorCallback(array($this, 'handleError'));
 
@@ -261,13 +264,12 @@ class Ethna_Controller
 
         // プラグインオブジェクトの用意
         $this->plugin = $this->getPlugin();
+        $this->plugin->setLogger($this->logger);
 
         // include Ethna_Plugin_Abstract for all plugins
         $this->plugin->includePlugin('Abstract');
 
         // ログ出力開始
-        $this->logger = $this->getLogger();
-        $this->plugin->setLogger($this->logger);
         $this->logger->begin();
     }
 


### PR DESCRIPTION
Logger の生成がエラーハンドラの設定よりも後だと、エラーハンドラが呼ばれた際に Fatal Error が発生するので、Logger の生成をエラーハンドラの生成よりも前へ移動しました。

なお、ログ出力の開始は Plugin の初期化に依存するので、現在の位置のままにしています。
