### PR TITLE
Feature/fix http header

### DIFF
--- a/class/ViewClass.php
+++ b/class/ViewClass.php
@@ -236,7 +236,7 @@ class Ethna_ViewClass
             );
 
             if (array_key_exists($status, $codes)) {
-                header("HTTP/1.1: {$status} {$codes[$status]}");
+                header("HTTP/1.1 {$status} {$codes[$status]}");
             }
         } else {
             // check valid header


### PR DESCRIPTION
View クラスで定義されている header メソッドの HTTP ヘッダーの書式が間違っています。
このバグがあると、Safari で View クラスの redirect メソッドが正しく機能せず、200 OK が返ってしまいます。
